### PR TITLE
Identify unused function parameters regardless of local vars + fix-all.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ Running `bslint` with `--fix` parameter will attempt to fix common code-style is
 - Case sensitivity (align with first occurence)
 - Adding/removing newlines the end of non-empty files.
 
+Running `bslint` with `--fix-all` parameter will include all fixes from `--fix`, plus some advanced code changes:
+
+- Unused parameters (prefixed with `_`)
+
 ## Usage checking (approximative)
 
 Running `bslint` with `--checkUsage` parameter will attempt to identify unused components and scripts:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,8 @@ const options = yargs
         description: 'Path to the root of your project files (where the manifest lives). Defaults to current directory.'
     })
     .option('lintConfig', { type: 'string', description: 'Path to a bslint.json configuration file.' })
-    .option('fix', { type: 'boolean', description: 'Fix automatically minor issues (experimental)' })
+    .option('fix', { type: 'boolean', description: 'Automatically fix minor issues (experimental)' })
+    .option('fix-all', { type: 'boolean', description: 'Automatically fix all issues, including advanced code changes (experimental)' })
     .option('checkUsage', { type: 'boolean', description: 'Look for potentially unused components and scripts' })
     .option('watch', { type: 'boolean', defaultDescription: 'false', description: 'Watch input files.' }).argv;
 
@@ -28,6 +29,7 @@ async function run(options: BsLintConfig) {
     }
     if (options.watch) {
         options.fix = false;
+        options.fixAll = false;
     }
     const config = normalizeConfig(options);
     const linter = new Linter();

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export type BsLintConfig = Pick<BsConfig, 'project' | 'rootDir' | 'files' | 'cwd
     globals?: string[];
     ignores?: string[];
     fix?: boolean;
+    fixAll?: boolean;
     checkUsage?: boolean;
 };
 

--- a/src/plugins/codeStyle/index.ts
+++ b/src/plugins/codeStyle/index.ts
@@ -42,7 +42,7 @@ export default class CodeStyle {
 
     onGetCodeActions(event: OnGetCodeActionsEvent) {
         const addFixes = addFixesToEvent(event);
-        extractFixes(addFixes, event.diagnostics);
+        extractFixes(addFixes, event.diagnostics, this.lintContext.fixAll);
     }
 
     validateXMLFile(file: XmlFile) {
@@ -286,11 +286,9 @@ export default class CodeStyle {
             file
         }));
 
-        const { fix } = this.lintContext;
-
         // apply fix
-        if (fix) {
-            bsDiagnostics = extractFixes(this.lintContext.addFixes, bsDiagnostics);
+        if (this.lintContext.fix) {
+            bsDiagnostics = extractFixes(this.lintContext.addFixes, bsDiagnostics, this.lintContext.fixAll);
         }
 
         // append diagnostics

--- a/src/plugins/codeStyle/styleFixes.ts
+++ b/src/plugins/codeStyle/styleFixes.ts
@@ -5,9 +5,13 @@ import { platform } from 'process';
 
 export function extractFixes(
     addFixes: (file: BscFile, changes: ChangeEntry) => void,
-    diagnostics: BsDiagnostic[]
+    diagnostics: BsDiagnostic[],
+    fixAll?: boolean
 ): BsDiagnostic[] {
     return diagnostics.filter(diagnostic => {
+        if (diagnostic.data?.isExperimental && !fixAll) {
+            return true;
+        }
         const fix = getFixes(diagnostic);
         if (fix) {
             addFixes(diagnostic.file, fix);

--- a/src/plugins/trackCodeFlow/fixAll.spec.ts
+++ b/src/plugins/trackCodeFlow/fixAll.spec.ts
@@ -1,0 +1,111 @@
+import * as fs from 'fs';
+import { expect } from 'chai';
+import { Program } from 'brighterscript';
+import Linter from '../../Linter';
+import TrackCodeFlow from './index';
+import bslintFactory from '../../index';
+import { createContext, PluginWrapperContext } from '../../util';
+
+describe('trackCodeFlow fixAll', () => {
+    let linter: Linter;
+    let lintContext: PluginWrapperContext;
+    let program: Program;
+    const project1 = {
+        rootDir: 'test/project1'
+    };
+    const tempFile = `${project1.rootDir}/source/unused-parameter-temp.brs`;
+    const sourceFile = `${project1.rootDir}/source/unused-parameter.brs`;
+
+    beforeEach(() => {
+        linter = new Linter();
+        program = new Program({});
+        program.plugins.add(bslintFactory());
+        program.plugins.emit('afterProgramCreate', program);
+
+        linter.builder.plugins.add({
+            name: 'test',
+            afterProgramCreate: (program: Program) => {
+                lintContext = createContext(program);
+                const trackCodeFlow = new TrackCodeFlow(lintContext);
+                program.plugins.add(trackCodeFlow);
+            }
+        });
+
+        if (fs.existsSync(tempFile)) {
+            fs.unlinkSync(tempFile);
+        }
+        fs.copyFileSync(sourceFile, tempFile);
+    });
+
+    afterEach(() => {
+        if (fs.existsSync(tempFile)) {
+            fs.unlinkSync(tempFile);
+        }
+    });
+
+    it('fixes unused parameter when fixAll is true', async () => {
+        await linter.run({
+            ...project1,
+            files: ['source/unused-parameter-temp.brs'],
+            rules: {
+                'unused-parameter': 'error'
+            },
+            fix: true,
+            fixAll: true
+        } as any);
+
+        await lintContext.applyFixes();
+
+        const content = fs.readFileSync(tempFile).toString();
+        expect(content).to.contain('sub error1(_unusedParam)');
+    });
+
+    it('does not fix unused parameter when fixAll is false', async () => {
+        await linter.run({
+            ...project1,
+            files: ['source/unused-parameter-temp.brs'],
+            rules: {
+                'unused-parameter': 'error'
+            },
+            fix: true,
+            fixAll: false
+        } as any);
+
+        await lintContext.applyFixes();
+
+        const content = fs.readFileSync(tempFile).toString();
+        expect(content).to.contain('sub error1(unusedParam)');
+    });
+
+    it('does not fix unused parameter when fixAll is missing', async () => {
+        await linter.run({
+            ...project1,
+            files: ['source/unused-parameter-temp.brs'],
+            rules: {
+                'unused-parameter': 'error'
+            },
+            fix: true
+        } as any);
+
+        await lintContext.applyFixes();
+
+        const content = fs.readFileSync(tempFile).toString();
+        expect(content).to.contain('sub error1(unusedParam)');
+    });
+
+    it('fixes unused parameter when fixAll is true and fix is not provided', async () => {
+        await linter.run({
+            ...project1,
+            files: ['source/unused-parameter-temp.brs'],
+            rules: {
+                'unused-parameter': 'error'
+            },
+            fixAll: true
+        } as any);
+
+        await lintContext.applyFixes();
+
+        const content = fs.readFileSync(tempFile).toString();
+        expect(content).to.contain('sub error1(_unusedParam)');
+    });
+});

--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -372,7 +372,9 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `01:LINT1006:Parameter 'unusedParam' is set but value is never used`
+            `01:LINT1006:Parameter 'unusedParam' is set but value is never used`,
+            `06:LINT1006:Parameter 'unusedParamNoLocal' is set but value is never used`,
+            `09:LINT1006:Parameter 'unusedParamNoLocal' is set but value is never used`
         ];
         expect(actual).deep.equal(expected);
     });

--- a/src/plugins/trackCodeFlow/index.ts
+++ b/src/plugins/trackCodeFlow/index.ts
@@ -59,7 +59,7 @@ export default class TrackCodeFlow {
 
     onGetCodeActions(event: OnGetCodeActionsEvent) {
         const addFixes = addFixesToEvent(event);
-        extractFixes(addFixes, event.diagnostics);
+        extractFixes(addFixes, event.diagnostics, this.lintContext.fixAll);
     }
 
     afterScopeValidate(scope: Scope, files: BscFile[], callables: CallableContainerMap) {
@@ -170,7 +170,7 @@ export default class TrackCodeFlow {
         });
 
         if (this.lintContext.fix) {
-            diagnostics = extractFixes(this.lintContext.addFixes, diagnostics);
+            diagnostics = extractFixes(this.lintContext.addFixes, diagnostics, this.lintContext.fixAll);
         }
 
         file.addDiagnostics(diagnostics);

--- a/src/plugins/trackCodeFlow/trackFixes.ts
+++ b/src/plugins/trackCodeFlow/trackFixes.ts
@@ -4,10 +4,14 @@ import { VarLintError } from './varTracking';
 
 export function extractFixes(
     addFixes: (file: BscFile, changes: ChangeEntry) => void,
-    diagnostics: BsDiagnostic[]
+    diagnostics: BsDiagnostic[],
+    fixAll?: boolean
 ): BsDiagnostic[] {
     return diagnostics.filter(diagnostic => {
-        const fix = getFixes(diagnostic);
+        if (diagnostic.data?.isExperimental && !fixAll) {
+            return true;
+        }
+        const fix = getFixes(diagnostic, fixAll);
         if (fix) {
             addFixes(diagnostic.file, fix);
             return false;
@@ -16,10 +20,12 @@ export function extractFixes(
     });
 }
 
-export function getFixes(diagnostic: BsDiagnostic): ChangeEntry {
+export function getFixes(diagnostic: BsDiagnostic, fixAll?: boolean): ChangeEntry {
     switch (diagnostic.code) {
         case VarLintError.CaseMismatch:
             return fixCasing(diagnostic);
+        case VarLintError.UnusedParameter:
+            return fixUnusedParameter(diagnostic);
         default:
             return null;
     }
@@ -31,6 +37,17 @@ function fixCasing(diagnostic: BsDiagnostic) {
         diagnostic,
         changes: [
             replaceText(data.range, data.name)
+        ]
+    };
+}
+
+function fixUnusedParameter(diagnostic: BsDiagnostic) {
+    const data: { name: string; range: Range } = diagnostic.data;
+    const newName = `_${data.name}`;
+    return {
+        diagnostic,
+        changes: [
+            replaceText(data.range, newName, data.name)
         ]
     };
 }

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -90,6 +90,7 @@ export function createVarLinter(
         };
         if (arg) {
             verifyVarCasing(arg, name);
+            arg.isUsed = true;
             return local;
         }
 
@@ -152,7 +153,7 @@ export function createVarLinter(
     function openBlock(block: StatementInfo) {
         const { stat } = block;
         if (isForStatement(stat)) {
-            // for iterator will be declared by the next assignement statement
+            // for iterator will be declared by the next assignment statement
         } else if (isForEachStatement(stat)) {
             // declare `for each` iterator variable
             setLocal(block, stat.item, VarRestriction.Iterator);
@@ -213,7 +214,8 @@ export function createVarLinter(
         const { locals, branches, returns } = closed;
         const { parent } = state;
         if (!locals || !parent) {
-            if (locals) {
+            // Finalize when there's no parent, i.e. end of function
+            if (!parent) {
                 finalize(locals);
             }
             return;
@@ -352,8 +354,8 @@ export function createVarLinter(
         return true;
     }
 
-    function finalize(locals: Map<string, VarInfo>) {
-        locals.forEach(local => {
+    function finalize(locals?: Map<string, VarInfo>) {
+        locals?.forEach(local => {
             if (!local.isUsed && !local.restriction) {
                 diagnostics.push({
                     severity: severity.unusedVariable,
@@ -365,7 +367,7 @@ export function createVarLinter(
             }
         });
 
-        args.forEach(arg => {
+        args?.forEach(arg => {
             // treat a leading underscore as an intentionally unused parameter
             if (!arg.isUsed && !arg.name.startsWith('_')) {
                 diagnostics.push({

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -375,7 +375,12 @@ export function createVarLinter(
                     code: VarLintError.UnusedParameter,
                     message: `Parameter '${arg.name}' is set but value is never used`,
                     range: arg.range,
-                    file: file
+                    file: file,
+                    data: {
+                        name: arg.name,
+                        range: arg.range,
+                        isExperimental: true
+                    }
                 });
             }
         });

--- a/src/textEdit.spec.ts
+++ b/src/textEdit.spec.ts
@@ -79,28 +79,32 @@ describe('getLineOffsets', () => {
 
 describe('applyEdits', () => {
     it('Edits in the right order', () => {
-        const newSrc = applyEdits(
-            'line 1\nline 2', [{
-                range: Range.create(0, 0, 0, 6),
-                text: 'replaced line 1!'
-            }, {
-                range: Range.create(1, 5, 1, 6),
-                text: '(2)'
-            }]
-        );
+        const edits = [
+            {
+                diagnostic: { code: 0, message: 'dummy' } as any,
+                changes: [
+                    { range: Range.create(0, 0, 0, 6), text: 'replaced line 1!' },
+                    { range: Range.create(1, 5, 1, 6), text: '(2)' }
+                ]
+            }
+        ];
+
+        const { newSrc } = applyEdits('line 1\nline 2', edits);
         expect(newSrc).equals('replaced line 1!\nline (2)');
     });
 
     it('Edits in the reverse order', () => {
-        const newSrc = applyEdits(
-            'line 1\nline 2', [{
-                range: Range.create(1, 5, 1, 6),
-                text: '(2)'
-            }, {
-                range: Range.create(0, 0, 0, 6),
-                text: 'replaced line 1!'
-            }]
-        );
+        const edits = [
+            {
+                diagnostic: { code: 0, message: 'dummy' } as any,
+                changes: [
+                    { range: Range.create(1, 5, 1, 6), text: '(2)' },
+                    { range: Range.create(0, 0, 0, 6), text: 'replaced line 1!' }
+                ]
+            }
+        ];
+
+        const { newSrc } = applyEdits('line 1\nline 2', edits);
         expect(newSrc).equals('replaced line 1!\nline (2)');
     });
 });

--- a/src/textEdit.ts
+++ b/src/textEdit.ts
@@ -13,6 +13,7 @@ interface LintCodeAction {
 export interface TextEdit {
     range: Range;
     text: string;
+    expectedText?: string;
 }
 
 export interface ChangeEntry {
@@ -20,11 +21,12 @@ export interface ChangeEntry {
     changes: TextEdit[];
 }
 
-export function replaceText(range: Range, text: string) {
+export function replaceText(range: Range, text: string, expectedText?: string) {
     return {
         type: 'replace',
         range,
-        text
+        text,
+        expectedText
     };
 }
 
@@ -94,32 +96,77 @@ export function rangeToOffset(lineOffsets: number[], range: Range) {
     };
 }
 
-export function applyEdits(src: string, changes: TextEdit[]) {
-    const lineOffsets = getLineOffsets(src);
-    const edits = [...changes].sort(compareRanges).reverse();
-    let newSrc = src;
-    edits.forEach(edit => {
-        const offsets = rangeToOffset(lineOffsets, edit.range);
-        if (offsets) {
-            newSrc = newSrc.substr(0, offsets.start) + edit.text + newSrc.substr(offsets.end);
-        }
-    });
-    return newSrc;
+export interface SkippedEditInfo {
+    edit: TextEdit;
+    diagnostic: BsDiagnostic;
+    startOffset: number;
+    endOffset: number;
+    foundText: string;
 }
 
-export async function applyFixes(fix: boolean, pendingFixes: Map<string, TextEdit[]>) {
+export function applyEdits(src: string, entries: ChangeEntry[]) {
+    const lineOffsets = getLineOffsets(src);
+    // flatten while keeping diagnostic reference
+    const editsWithDiag = entries.flatMap(entry => entry.changes.map(edit => ({ edit, diagnostic: entry.diagnostic })));
+
+    const sortedEdits = [...editsWithDiag].sort((a, b) => compareRanges(a.edit, b.edit)).reverse();
+
+    let newSrc = src;
+    const skippedEdits: SkippedEditInfo[] = [];
+
+    for (const { edit, diagnostic } of sortedEdits) {
+        const offsets = rangeToOffset(lineOffsets, edit.range);
+        if (!offsets) {
+            continue;
+        }
+
+        if (edit.expectedText) {
+            const currentText = newSrc.slice(offsets.start, offsets.end);
+            if (currentText !== edit.expectedText) {
+                skippedEdits.push({
+                    edit,
+                    diagnostic,
+                    startOffset: offsets.start,
+                    endOffset: offsets.end,
+                    foundText: currentText
+                });
+                continue;
+            }
+        }
+
+        newSrc = newSrc.slice(0, offsets.start) + edit.text + newSrc.slice(offsets.end);
+    }
+
+    return { newSrc, skippedEdits };
+}
+
+export async function applyFixes(
+    fix: boolean,
+    pendingFixes: Map<string, ChangeEntry[]>
+) {
     if (!fix || !pendingFixes || pendingFixes.size === 0) {
         return;
     }
+
     for (const file of pendingFixes.keys()) {
-        const changes = pendingFixes.get(file);
-        if (changes?.length && existsSync(file)) {
+        const entries = pendingFixes.get(file);
+        if (entries?.length && existsSync(file)) {
             const src = (await readFile(file)).toString();
-            const newSrc = applyEdits(src, changes);
-            if (newSrc !== src) {
+            const { newSrc, skippedEdits } = applyEdits(src, entries);
+
+            if (skippedEdits.length > 0) {
+                skippedEdits.forEach((skipped) => {
+                    console.warn(
+                        `Skipped fix in ${file} at range [${skipped.startOffset}, ${skipped.endOffset}]: ` +
+                        `expected "${skipped.edit.expectedText}", found "${skipped.foundText}"\n` +
+                        `Diagnostic: ${skipped.diagnostic.message}`
+                    );
+                });
+            } else if (newSrc !== src) {
                 await writeFile(file, newSrc);
             }
         }
+
         pendingFixes.delete(file);
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,7 @@ import { BsLintConfig, BsLintRules, RuleSeverity, BsLintSeverity } from './index
 import { readFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import { Program, BscFile, DiagnosticSeverity } from 'brighterscript';
-import { applyFixes, ChangeEntry, TextEdit } from './textEdit';
+import { applyFixes, ChangeEntry } from './textEdit';
 import { addJob } from './Linter';
 
 export function getDefaultRules(): BsLintConfig['rules'] {
@@ -43,7 +43,11 @@ export function normalizeConfig(options: BsLintConfig) {
         rules: getDefaultRules()
     };
     const projectConfig = mergeConfigs(loadConfig(options), { rules: options.rules });
-    return mergeConfigs(baseConfig, projectConfig);
+    const result = mergeConfigs(baseConfig, projectConfig);
+    if (result.fixAll) {
+        result.fix = true;
+    }
+    return result;
 }
 
 export function mergeConfigs(a: BsLintConfig, b: BsLintConfig): BsLintConfig {
@@ -105,21 +109,22 @@ export interface PluginContext {
     globals: string[];
     ignores: (file: BscFile) => boolean;
     fix: Readonly<boolean>;
+    fixAll: Readonly<boolean>;
     checkUsage: Readonly<boolean>;
     addFixes: (file: BscFile, entry: ChangeEntry) => void;
 }
 
 export interface PluginWrapperContext extends PluginContext {
-    pendingFixes: Map<string, TextEdit[]>;
+    pendingFixes: Map<string, ChangeEntry[]>;
     applyFixes: () => Promise<void>;
 }
 
 export function createContext(program: Program): PluginWrapperContext {
-    const { rules, fix, checkUsage, globals, ignores } = normalizeConfig(program.options);
+    const { rules, fix, fixAll, checkUsage, globals, ignores } = normalizeConfig(program.options);
     const ignorePatterns = (ignores || []).map(pattern => {
         return pattern.startsWith('**/') ? pattern : '**/' + pattern;
     });
-    const pendingFixes = new Map<string, TextEdit[]>();
+    const pendingFixes = new Map<string, ChangeEntry[]>();
     return {
         program: program,
         severity: rulesToSeverity(rules),
@@ -129,12 +134,13 @@ export function createContext(program: Program): PluginWrapperContext {
             return !file || ignorePatterns.some(pattern => minimatch(file.pathAbsolute, pattern));
         },
         fix,
+        fixAll,
         checkUsage,
         addFixes: (file: BscFile, entry: ChangeEntry) => {
             if (!pendingFixes.has(file.pathAbsolute)) {
-                pendingFixes.set(file.pathAbsolute, entry.changes);
+                pendingFixes.set(file.pathAbsolute, [entry]);
             } else {
-                pendingFixes.get(file.pathAbsolute).push(...entry.changes);
+                pendingFixes.get(file.pathAbsolute).push(entry);
             }
         },
         applyFixes: () => addJob(applyFixes(fix, pendingFixes)),

--- a/test/project1/source/unused-parameter.brs
+++ b/test/project1/source/unused-parameter.brs
@@ -3,6 +3,21 @@ sub error1(unusedParam) ' error
     print a
 end sub
 
+sub error2(unusedParamNoLocal) ' error
+end sub
+
+sub error3(a, b, c, unusedParamNoLocal) ' error
+    if a then
+        print "true"
+    end if
+
+    print b
+
+    if c = "none" then
+        print "none"
+    end if
+end sub
+
 sub ok1(x)
     a = 8
     if a > x
@@ -13,4 +28,7 @@ end sub
 sub ok2(_explicitlyUnused)
     a = 10
     print a
+end sub
+
+sub ok3(_explicitlyUnusedNoLocal)
 end sub


### PR DESCRIPTION
Fixes an issue where bslint was not identifying unused parameters unless a local variable was used. It also adds support to fix these with --fix-all.